### PR TITLE
Fix bug with build_view crashing when presented with an empty list

### DIFF
--- a/mullemeck/templates/build_view.html
+++ b/mullemeck/templates/build_view.html
@@ -97,6 +97,7 @@
     </div>
   </div>
   <div id="page_body">
+  {% if (build_list.list[build_list.pointer-1]|length) > 0 %}
     <p>
       <h2>Build ID: {{ build_list.list[build_list.pointer-1][0].id }} </h2>
     </p>
@@ -116,6 +117,12 @@
       <p id="row_list"> {{row}} </p>
     {% endfor %}
   </div>
+  {% endif %}
+  {% if (build_list.list[build_list.pointer-1]|length) == 0 %}
+    <p>
+      <h2>Your database is empty :(</h2>
+    </p>
+  {% endif %}
   <div id="page_footer"> Pages:
       {% for x in range(1, build_list.number_of_pages+1) %}
           <a id="build_link" href="{{ url_for('build_view', page_num=x) }}">{{ x }}</a>


### PR DESCRIPTION
Fixes: #109 
Fixed bug with build_view crashing when presented with an empty list.